### PR TITLE
FIX: Reworks metadata handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Cyotek Quick Scan Change Log
 
+## 1.2.1 (08Oct2022)
+
+### Fixed
+
+* Metadata tokens are now evaluated on demand, preventing a
+  fatal crash which sometimes occurred when saving an image and
+  trying to read all WIA device properties
+* Timestamp saved into images is now the timestamp of the scan,
+  not that of the time the image was saved
+
 ## 1.2 (04Oct2022)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -118,12 +118,7 @@ the **Output Folder** field will need to be reset.
   110 and 220, I haven't had any issues. With the Plustek
   OpticSlim 1180 I _always_ have to display the WIA Scan
   dialogue and reselect all parameters
-* Rarely, the program will crash when trying to read WIA
-  properties in order to generate EXIF metadata. When this
-  happens, I usually just start again from where I left off
-  (remembering to manually reset the counter!) as lightening
-  generally doesn't hit twice. I have ideas on resolving this in
-  a future PR.
+* Rarely, reading WIA properties causes a crash
 * Sometimes, an image is so large the program crashes trying to
   save the modified version. When this happens, Quick Scan will
   instead save the original image from the scanner. This keeps

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -42,6 +42,8 @@ namespace Cyotek.QuickScan
 
     private bool _isLimitedUi;
 
+    private DateTimeOffset _lastScanDateTime;
+
     private Settings _settings;
 
     private SoundPlayer _soundPlayer;
@@ -128,13 +130,9 @@ namespace Cyotek.QuickScan
 
     private void AddMetadata(Image image)
     {
-      Dictionary<string, string> fields;
-
-      fields = this.GetMergeFields();
-
       foreach (KeyValuePair<PropertyTag, Tuple<PropertyTagType, string>> pair in _settings.Metadata)
       {
-        image.SetPropertyItem(pair.Key, pair.Value.Item1, pair.Value.Item2.MailMerge(fields, '{', '}'));
+        image.SetPropertyItem(pair.Key, pair.Value.Item1, pair.Value.Item2.MailMerge('{', '}', this.EvaluateMergeToken));
       }
     }
 
@@ -339,6 +337,57 @@ namespace Cyotek.QuickScan
       this.ApplySettings();
     }
 
+    private string EvaluateMergeToken(string token)
+    {
+      string result;
+
+      if (token.EqualsIgnoreCase("now"))
+      {
+        result = _lastScanDateTime.ToString("s");
+      }
+      else if (token.EqualsIgnoreCase("now:exif"))
+      {
+        result = _lastScanDateTime.ToString("yyyy:MM:dd HH:mm:ss");
+      }
+      else if (token.EqualsIgnoreCase("year"))
+      {
+        result = _lastScanDateTime.Year.ToString(CultureInfo.InvariantCulture);
+      }
+      else if (token.EqualsIgnoreCase("appname"))
+      {
+        result = Application.ProductName;
+      }
+      else if (token.EqualsIgnoreCase("appversion"))
+      {
+        result = Application.ProductVersion;
+      }
+      else if (token != null && token.Length > 1 && token[0] == '#')
+      {
+        result = null;
+        token = token.Substring(1);
+
+        // TODO: This will be wrong if multiple devices are present and the user
+        // chooses a different one from the dialog versus this selection
+        this.PerformDeviceAction(device =>
+        {
+          foreach (Property property in device.Properties)
+          {
+            if (property.Name.EqualsIgnoreCase(token))
+            {
+              result = property.GetValueString();
+              break;
+            }
+          }
+        });
+      }
+      else
+      {
+        result = null;
+      }
+
+      return result;
+    }
+
     private void ExitToolStripMenuItem_Click(object sender, EventArgs e)
     {
       this.Close();
@@ -476,32 +525,6 @@ namespace Cyotek.QuickScan
       this.HideContinuationBar();
 
       return _continuationResult;
-    }
-
-    private Dictionary<string, string> GetMergeFields()
-    {
-      Dictionary<string, string> fields;
-
-      fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-      {
-        { "now", DateTime.UtcNow.ToString("s") },
-        { "now:exif", DateTime.UtcNow.ToString("yyyy:MM:dd HH:mm:ss") },
-        { "year", DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture) },
-        { "appname", Application.ProductName },
-        { "appversion", Application.ProductVersion },
-      };
-
-      // TODO: This will be wrong if multiple devices are present and the user
-      // chooses a different one from the dialog versus this selection
-      this.PerformDeviceAction(device =>
-      {
-        foreach (Property property in device.Properties)
-        {
-          fields.Add("#" + property.Name, property.GetValueString());
-        }
-      });
-
-      return fields;
     }
 
     private Device GetSelectedDevice()
@@ -911,6 +934,8 @@ namespace Cyotek.QuickScan
           if (image != null)
           {
             string fileName;
+
+            _lastScanDateTime = DateTimeOffset.UtcNow;
 
             this.SetImage(image);
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("6802c96f-97bd-4ac1-b399-d0f97a1d4be4")]
 [assembly: CLSCompliant(true)]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/src/PropertiesDialog.cs
+++ b/src/PropertiesDialog.cs
@@ -91,7 +91,14 @@ namespace Cyotek.QuickScan
           property = _properties[i + 1];
           type = (WiaPropertyType)property.Type;
 
-          value = property.GetValueString();
+          try
+          {
+            value = property.GetValueString();
+          }
+          catch (Exception ex)
+          {
+            value = "{" + ex.Message + "}";
+          }
 
           item = new ListViewItem();
 

--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 // Cyotek Quick Scan
@@ -18,9 +19,11 @@ namespace Cyotek.QuickScan
   {
     #region Public Methods
 
-    public static string MailMerge(this string text, IDictionary<string, string> tokens, char tokenStart, char tokenEnd)
+    public static bool EqualsIgnoreCase(this string a, string b) => string.Equals(a, b, StringComparison.InvariantCultureIgnoreCase);
+
+    public static string MailMerge(this string text, char tokenStart, char tokenEnd, Func<string, string> evaluate)
     {
-      if (text != null && tokens != null && tokens.Count != 0)
+      if (text != null)
       {
         int length;
 
@@ -49,16 +52,14 @@ namespace Cyotek.QuickScan
             else if (c == tokenEnd && readingField)
             {
               string key;
+              string result;
 
               key = name.ToString();
+              result = evaluate(key);
 
-              if (tokens.TryGetValue(key, out string value))
+              if (result != null)
               {
-                sb.Append(value);
-              }
-              else if (tokens.TryGetValue(tokenStart + key + tokenEnd, out value))
-              {
-                sb.Append(value);
+                sb.Append(result);
               }
               else
               {


### PR DESCRIPTION
Device properties are now read on demand, instead
of being defined up front - this occasionally
resulted in an exception that would silently
terminate the process